### PR TITLE
Fix: Invalid shell code comparison check

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -73,34 +73,22 @@ runs:
 
         # pyproject.toml is preferred source if both files exist
         if [ ${{ steps.pyproject-toml.outputs.type }} = 'file' ]; then
-          echo "Using project name from: pyproject.toml"
           PYTHON_PROJECT_NAME="${{ steps.pyproject-name.outputs.extracted_string}}"
           PYTHON_PROJECT_FILE="pyproject.toml"
+          echo "Using project name from: pyproject.toml ✅"
 
-        elif [ ${{ steps.setup-py.outputs.type == 'file' }} ]; then
-
-          # This is a legacy format and does not conform to the latest PEP standards
-
-          echo "Using project name from: setup.py"
+        # Legacy format; does not conform to the latest PEP standards
+        elif [ "${{ steps.setup-py.outputs.type }}" = 'file' ]; then
           PYTHON_PROJECT_NAME="${{ steps.setup-name.outputs.extracted_string}}"
           PYTHON_PROJECT_FILE="setup.py"
-
-          # Project is defined using legacy standards
-          echo "# ⚠️ Project using outdated format: setup.py"
-          echo "This Python project format is deprecated"
-          echo "The repository content needs updating"
-
-          echo "# ⚠️ Project using outdated format: setup.py" >> "$GITHUB_STEP_SUMMARY"
-          echo "This Python project format is deprecated" >> "$GITHUB_STEP_SUMMARY"
-          echo "The repository content needs updating" >> "$GITHUB_STEP_SUMMARY"
+          echo "Using project name from: setup.py ⚠️"
         fi
 
         if [ -z "$PYTHON_PROJECT_NAME" ]; then
           echo "Python project name extraction failed ❌"
           exit 1
         fi
-
-        echo "Python project name: $PYTHON_PROJECT_NAME ✅"
+        echo "Python project name: $PYTHON_PROJECT_NAME 💬"
 
         # Replace all dashes in the name with underscores
         PYTHON_PACKAGE_NAME=$(echo "$PYTHON_PROJECT_NAME" | tr '-' '_')


### PR DESCRIPTION
Also, setup.py/setuptools is not officially deprecated, but some of the CLI tools are. Improve the action output to better reflect this fact.