### PR TITLE
Feat: Support setup.cfg project name extraction

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -132,3 +132,110 @@ jobs:
             echo "At least one output test failed for python-nss-ng ❌"
             exit 1
           fi
+
+      # Third test: synthetic setup.cfg fixture (legacy pbr/setuptools).
+      # Verifies the new setup.cfg → [metadata] name extraction path,
+      # including: case-insensitive section/key matching, `:` delimiter
+      # support, inline `;` comment stripping, and selection of source.
+      - name: "Create setup.cfg fixture"
+        shell: bash
+        run: |
+          mkdir -p test-setup-cfg
+          cat > test-setup-cfg/setup.cfg <<'EOF'
+          [Metadata]
+          Name: lfdocs-conf  ; canonical project name
+          author = LF
+
+          [options.entry_points]
+          name = wrong
+          EOF
+          cat > test-setup-cfg/setup.py <<'EOF'
+          from setuptools import setup
+          setup(setup_requires=["pbr"], pbr=True)
+          EOF
+
+      - name: "Run Action: ${{ github.repository }} [setup.cfg fixture]"
+        id: test-setup-cfg
+        uses: ./
+        with:
+          path_prefix: "test-setup-cfg/"
+
+      - name: "Validate Action Output: setup.cfg fixture"
+        shell: bash
+        env:
+          PROJECT_FILE: ${{ steps.test-setup-cfg.outputs.python_project_file }}
+          PROJECT_NAME: ${{ steps.test-setup-cfg.outputs.python_project_name }}
+          PACKAGE_NAME: ${{ steps.test-setup-cfg.outputs.python_package_name }}
+          SOURCE: ${{ steps.test-setup-cfg.outputs.source }}
+        run: |
+          # Validate setup.cfg fixture extraction
+          ERROR=""
+          if [ "$PROJECT_FILE" != "setup.cfg" ]; then
+            echo "Unexpected python_project_file: $PROJECT_FILE ❌"
+            ERROR="true"
+          fi
+          if [ "$PROJECT_NAME" != "lfdocs-conf" ]; then
+            echo "Unexpected python_project_name: $PROJECT_NAME ❌"
+            ERROR="true"
+          fi
+          if [ "$PACKAGE_NAME" != "lfdocs_conf" ]; then
+            echo "Unexpected python_package_name: $PACKAGE_NAME ❌"
+            ERROR="true"
+          fi
+          if [ "$SOURCE" != "setup.cfg" ]; then
+            echo "Unexpected source: $SOURCE ❌"
+            ERROR="true"
+          fi
+          if [ "$ERROR" != "true" ]; then
+            echo "All output tests passed for setup.cfg fixture ✅"
+          else
+            exit 1
+          fi
+
+      # Fourth test: setup.cfg present but with no [metadata] name should
+      # fall through to setup.py.
+      - name: "Create setup.cfg fall-through fixture"
+        shell: bash
+        run: |
+          mkdir -p test-setup-cfg-fallthrough
+          cat > test-setup-cfg-fallthrough/setup.cfg <<'EOF'
+          [options]
+          packages = find:
+          EOF
+          cat > test-setup-cfg-fallthrough/setup.py <<'EOF'
+          from setuptools import setup
+          setup(name="fallthrough-pkg")
+          EOF
+
+      - name: "Run Action: ${{ github.repository }} [fall-through]"
+        id: test-fallthrough
+        uses: ./
+        with:
+          path_prefix: "test-setup-cfg-fallthrough/"
+
+      - name: "Validate Action Output: fall-through"
+        shell: bash
+        env:
+          PROJECT_FILE: ${{ steps.test-fallthrough.outputs.python_project_file }}
+          PROJECT_NAME: ${{ steps.test-fallthrough.outputs.python_project_name }}
+          SOURCE: ${{ steps.test-fallthrough.outputs.source }}
+        run: |
+          # Validate setup.cfg → setup.py fall-through
+          ERROR=""
+          if [ "$PROJECT_FILE" != "setup.py" ]; then
+            echo "Unexpected python_project_file: $PROJECT_FILE ❌"
+            ERROR="true"
+          fi
+          if [ "$PROJECT_NAME" != "fallthrough-pkg" ]; then
+            echo "Unexpected python_project_name: $PROJECT_NAME ❌"
+            ERROR="true"
+          fi
+          if [ "$SOURCE" != "setup.py" ]; then
+            echo "Unexpected source: $SOURCE ❌"
+            ERROR="true"
+          fi
+          if [ "$ERROR" != "true" ]; then
+            echo "All output tests passed for fall-through fixture ✅"
+          else
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -9,6 +9,23 @@ Extracts the Python project name and derives the Python package name.
 
 ## python-project-name-action
 
+The action probes the project for metadata in the following order,
+selecting the first present file (and, for `setup.cfg`, falling
+through to `setup.py` when the file is present but contains no
+`[metadata] name`):
+
+1. `pyproject.toml` — `[project] name` (PEP 621, preferred)
+2. `setup.cfg` — `[metadata] name` (legacy pbr / setuptools projects)
+3. `setup.py` — `name="…"` literal (legacy setuptools)
+
+If the chosen source is present but its name field is missing or
+empty, and no later source remains to try, the action fails rather
+than emitting an empty value.
+
+The `setup.cfg` and `setup.py` paths exist to support legacy projects
+(e.g. those still using `pbr`) that have not migrated to PEP 621
+metadata in `pyproject.toml`.
+
 ## Usage Example
 
 An example workflow step using this action:
@@ -34,10 +51,14 @@ steps:
 
 <!-- markdownlint-disable MD013 -->
 
-| Output Variable     | Mandatory | Value                                                     |
-| ------------------- | --------- | --------------------------------------------------------- |
-| PYTHON_PACKAGE_FILE | Yes       | File used to extract metadata: pyproject.toml or setup.py |
-| PYTHON_PROJECT_NAME | Yes       | Extracted from pyproject.toml/setup.py                    |
-| PYTHON_PACKAGE_NAME | Yes       | Derived from value in pyproject.toml/setup.py             |
+| Output Variable       | Mandatory | Value                                                            |
+| --------------------- | --------- | ---------------------------------------------------------------- |
+| `python_project_file` | Yes       | File used to extract metadata: pyproject.toml/setup.cfg/setup.py |
+| `python_project_name` | Yes       | Extracted from pyproject.toml, setup.cfg or setup.py             |
+| `python_package_name` | Yes       | Derived from the project name (dashes become underscores)        |
+| `source`              | Yes       | Source file used (pyproject.toml, setup.cfg or setup.py)         |
+
+The action also exports the same values as environment variables
+(lowercase names) for use in later steps within the same job.
 
 <!-- markdownlint-enable MD013 -->

--- a/action.yaml
+++ b/action.yaml
@@ -15,11 +15,12 @@ inputs:
 outputs:
   # Mandatory
   python_project_file:
-    # Supports both pyproject.toml and setup.py
+    # Supports pyproject.toml, setup.cfg and setup.py
     description: "File used to extract/parse project metadata"
     value: ${{ steps.capture.outputs.python_project_file }}
   python_project_name:
-    description: "Name of the Python project from pyproject.toml/setup.py"
+    description: >-
+      Name of the Python project from pyproject.toml/setup.cfg/setup.py
     value: ${{ steps.capture.outputs.python_project_name }}
   python_package_name:
     # Note: dashes in the name are substituted with underscores
@@ -28,7 +29,7 @@ outputs:
   source:
     description: >-
       Source file where project details were found
-      (pyproject.toml or setup.py)
+      (pyproject.toml, setup.cfg or setup.py)
     value: ${{ steps.capture.outputs.source }}
 
 runs:
@@ -71,11 +72,95 @@ runs:
         regex: '(?<=^name = ")([^"]*)'
         filename: "${{ env.path_prefix }}/pyproject.toml"
 
-    # Fall back to setup.py if pyproject.toml doesn't exist
+    # Fall back to setup.cfg ([metadata] name) for legacy pbr/setuptools
+    # yamllint disable-line rule:line-length
+    - uses: lfreleng-actions/path-check-action@9606e61c870025bc956e63156d1d55c5df54426c # v0.2.0
+      id: setup-cfg
+      if: steps.pyproject-toml.outputs.type != 'file'
+      with:
+        path: "${{ env.path_prefix }}/setup.cfg"
+
+    - name: "Get project name from setup.cfg"
+      id: setup-cfg-name
+      if: >-
+        steps.pyproject-toml.outputs.type != 'file' &&
+        steps.setup-cfg.outputs.type == 'file'
+      shell: bash
+      run: |
+        # Extract [metadata] name from setup.cfg
+        #
+        # Scope the match strictly to the [metadata] section so an
+        # unrelated `name =` (e.g. under [options.entry_points]) is
+        # not picked up. An empty / missing value is not an error
+        # here; the caller will fall through to setup.py.
+
+        cfg="${{ env.path_prefix }}/setup.cfg"
+        # Match setup.cfg parsing semantics used by configparser
+        # (setuptools/pbr): section names and option keys are
+        # case-insensitive; either `=` or `:` may delimit the
+        # key/value pair; and both `#` and `;` introduce inline
+        # comments. Normalize to lowercase before matching.
+        name=$(awk '
+          /^[[:space:]]*\[/ {
+            section=$0
+            sub(/^[[:space:]]*\[[[:space:]]*/, "", section)
+            sub(/[[:space:]]*\][[:space:]]*$/, "", section)
+            section=tolower(section)
+            next
+          }
+          {
+            line=$0
+          }
+          section == "metadata" && \
+            tolower(line) ~ /^[[:space:]]*name[[:space:]]*[=:]/ {
+            sub(/^[[:space:]]*[^=:]+[=:][[:space:]]*/, "", line)
+            sub(/[[:space:]]*([#;].*)?$/, "", line)
+            print line
+            exit
+          }
+        ' "$cfg")
+        # Defence in depth: only accept names matching a PEP 508-style
+        # project-name charset. Anything else (quotes, newlines, shell
+        # metacharacters) is treated as no match and falls through to
+        # setup.py, so a hostile setup.cfg cannot inject shell syntax
+        # into later steps that expand this output.
+        if ! printf '%s' "$name" | \
+            grep -Eq '^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$'; then
+          if [ -n "$name" ]; then
+            echo "Rejecting non-PEP-508 name from setup.cfg: $name ⚠️"
+          fi
+          name=""
+        fi
+        # Write output via the documented multiline delimiter form so
+        # that any unexpected newlines or special characters in the
+        # extracted value cannot inject additional step outputs.
+        # See:
+        # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+        # Use bash-only primitives ($RANDOM and $$) to build a
+        # delimiter unlikely to collide with content. Avoids a
+        # dependency on `uuidgen`, which may be absent in minimal
+        # runner / container images.
+        delim="EOF_${RANDOM}_${RANDOM}_$$"
+        {
+          echo "extracted_string<<$delim"
+          printf '%s\n' "$name"
+          echo "$delim"
+        } >> "$GITHUB_OUTPUT"
+        if [ -n "$name" ]; then
+          echo "Found name in setup.cfg [metadata]: $name 💬"
+        else
+          echo "No [metadata] name found in setup.cfg ⚠️"
+        fi
+
+    # Fall back to setup.py if neither pyproject.toml nor setup.cfg
+    # yielded a usable project name
     # yamllint disable-line rule:line-length
     - uses: lfreleng-actions/path-check-action@9606e61c870025bc956e63156d1d55c5df54426c # v0.2.0
       id: setup-py
-      if: steps.pyproject-toml.outputs.type != 'file'
+      if: >-
+        steps.pyproject-toml.outputs.type != 'file' &&
+        (steps.setup-cfg.outputs.type != 'file' ||
+         steps.setup-cfg-name.outputs.extracted_string == '')
       with:
         path: "${{ env.path_prefix }}/setup.py"
 
@@ -83,6 +168,8 @@ runs:
       id: setup-name
       if: >-
         steps.pyproject-toml.outputs.type != 'file' &&
+        (steps.setup-cfg.outputs.type != 'file' ||
+         steps.setup-cfg-name.outputs.extracted_string == '') &&
         steps.setup-py.outputs.type == 'file'
       # yamllint disable-line rule:line-length
       uses: lfreleng-actions/file-grep-regex-action@ba13750798b15e6acf23f3342a280ffc8148b950 # v0.1.4
@@ -94,25 +181,45 @@ runs:
     - name: "Capture Python project metadata"
       id: capture
       shell: bash
+      env:
+        # Pass step outputs in via the environment rather than
+        # interpolating them directly into the script body. This
+        # avoids any chance of repo-controlled values (notably the
+        # setup.cfg-derived name) breaking out of shell quoting in
+        # this step.
+        PYPROJECT_TOML_TYPE: ${{ steps.pyproject-toml.outputs.type }}
+        PYPROJECT_NAME: ${{ steps.pyproject-name.outputs.extracted_string }}
+        SETUP_CFG_TYPE: ${{ steps.setup-cfg.outputs.type }}
+        SETUP_CFG_NAME: ${{ steps.setup-cfg-name.outputs.extracted_string }}
+        SETUP_PY_TYPE: ${{ steps.setup-py.outputs.type }}
+        SETUP_PY_NAME: ${{ steps.setup-name.outputs.extracted_string }}
       # yamllint disable rule:line-length
       run: |
         # Capture Python project metadata
 
         # pyproject.toml is preferred source
-        if [ "${{ steps.pyproject-toml.outputs.type }}" = 'file' ]; then
-          PYTHON_PROJECT_NAME="${{ steps.pyproject-name.outputs.extracted_string }}"
+        if [ "$PYPROJECT_TOML_TYPE" = 'file' ]; then
+          PYTHON_PROJECT_NAME="$PYPROJECT_NAME"
           PYTHON_PROJECT_FILE="pyproject.toml"
           SOURCE="pyproject.toml"
           echo "Using project name from: pyproject.toml ✅"
 
-        # Fall back to setup.py if pyproject.toml not found
-        elif [ "${{ steps.setup-py.outputs.type }}" = 'file' ]; then
-          PYTHON_PROJECT_NAME="${{ steps.setup-name.outputs.extracted_string }}"
+        # Fall back to setup.cfg [metadata] (pbr / legacy setuptools)
+        elif [ "$SETUP_CFG_TYPE" = 'file' ] && \
+             [ -n "$SETUP_CFG_NAME" ]; then
+          PYTHON_PROJECT_NAME="$SETUP_CFG_NAME"
+          PYTHON_PROJECT_FILE="setup.cfg"
+          SOURCE="setup.cfg"
+          echo "Using project name from: setup.cfg ⚠️"
+
+        # Fall back to setup.py if neither of the above
+        elif [ "$SETUP_PY_TYPE" = 'file' ]; then
+          PYTHON_PROJECT_NAME="$SETUP_PY_NAME"
           PYTHON_PROJECT_FILE="setup.py"
           SOURCE="setup.py"
           echo "Using project name from: setup.py ⚠️"
         else
-          echo "Error: Neither pyproject.toml nor setup.py found ❌"
+          echo "Error: no pyproject.toml, setup.cfg or setup.py found ❌"
           exit 1
         fi
 


### PR DESCRIPTION
## Summary

Extends the action to read the project name from `setup.cfg`
`[metadata] name` (the `pbr` / legacy setuptools idiom), so it
works on projects that have not migrated their metadata to
`pyproject.toml` and whose `setup.py` is a bare `setup(pbr=True)`
call with no `name="…"` literal.

## Why

The current probe order is `pyproject.toml` → `setup.py`. Projects
like [`lfit/releng-docs-conf`](https://github.com/lfit/releng-docs-conf)
keep the canonical name in `setup.cfg`:

```ini
[metadata]
name = lfdocs_conf
```

…and a minimal `setup.py`:

```python
from setuptools import setup
setup(setup_requires=["pbr"], pbr=True, install_requires=install_reqs)
```

The existing `(?<=name=")([^"]*)` regex over `setup.py` matches
nothing, the action emits an empty `python_project_name`, and
downstream `python-audit-action` fails with:

```
String extraction failed; no matching value found ❌
```

Failing run for context:
https://github.com/lfit/releng-docs-conf/actions/runs/25217124950

This is the same shape of legacy-support gap recently closed in
`python-supported-versions-action`.

## Changes

- `action.yaml`
  - New `path-check-action` step for `setup.cfg`.
  - New `setup-cfg-name` step that uses an inline `awk` parser
    scoped to the `[metadata]` section, so a stray `name =` under
    e.g. `[options.entry_points]` is not mis-matched. Strips inline
    `# comment` trailers and surrounding whitespace.
  - The new step is non-fatal: when `setup.cfg` exists but has no
    `[metadata] name =`, the action falls through to `setup.py`.
  - Probe order is now **`pyproject.toml` → `setup.cfg` → `setup.py`**.
  - `Capture Python project metadata` extended with a `setup.cfg`
    branch; quoting around the existing step-output expansions
    tightened for consistency with the new clauses.
- `README.md`
  - Documents the precedence and frames `setup.cfg`/`setup.py` as
    legacy fallbacks. Adds the previously-undocumented `SOURCE`
    output to the table.

## Verification

`pre-commit run --all-files`: ✅ all hooks pass.

Manual smoke tests of the awk extractor against several
hand-written `setup.cfg` fixtures:

| Input                                                      | Extracted |
|------------------------------------------------------------|-----------|
| `[metadata]\nname = foo`                                   | `foo`     |
| `[metadata]\nname = foo-bar`                               | `foo-bar` |
| `[metadata]\nname=foo` (no spaces)                         | `foo`     |
| `[options.entry_points]\nname = wrong` (no metadata sect.) | *(empty)* |
| `[options.entry_points]` then `[metadata]\nname = real_name  # comment` | `real_name` |
| `[options]\npackages = find:` (no name at all)             | *(empty)* |
| `[metadata]\nname = lfdocs_conf\nauthor = LF`              | `lfdocs_conf` |

The empty-result cases correctly fall through to the `setup.py`
probe.

## Explicitly out of scope

No tests directory exists in this repo; this change does not
introduce a new test framework.