### PR TITLE
Fix: Handle pyproject without project name

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -244,3 +244,66 @@ jobs:
           else
             exit 1
           fi
+
+      # Fifth test: hybrid project carrying a [build-system]-only
+      # pyproject.toml (PEP 517) alongside a setup.cfg [metadata] name.
+      # This is the pbr / setuptools-legacy layout (e.g. lfdocs-conf):
+      # pyproject.toml exists but defines no [project] name, so the
+      # action must not abort on the empty pyproject result and must
+      # resolve the name from setup.cfg.
+      - name: "Create build-system-only pyproject.toml fixture"
+        shell: bash
+        run: |
+          mkdir -p test-pyproject-build-only
+          cat > test-pyproject-build-only/pyproject.toml <<'EOF'
+          [build-system]
+          requires = ["pbr>=7.0.0"]
+          build-backend = "pbr.build"
+          EOF
+          cat > test-pyproject-build-only/setup.cfg <<'EOF'
+          [metadata]
+          name = lfdocs-conf
+          author = LF
+          EOF
+          cat > test-pyproject-build-only/setup.py <<'EOF'
+          from setuptools import setup
+          setup(pbr=True)
+          EOF
+
+      - name: "Run Action: ${{ github.repository }} [build-system-only]"
+        id: test-build-only
+        uses: ./
+        with:
+          path_prefix: "test-pyproject-build-only/"
+
+      - name: "Validate Action Output: build-system-only pyproject.toml"
+        shell: bash
+        env:
+          PROJECT_FILE: ${{ steps.test-build-only.outputs.python_project_file }}
+          PROJECT_NAME: ${{ steps.test-build-only.outputs.python_project_name }}
+          PACKAGE_NAME: ${{ steps.test-build-only.outputs.python_package_name }}
+          SOURCE: ${{ steps.test-build-only.outputs.source }}
+        run: |
+          # Validate [build-system]-only pyproject.toml falls back to setup.cfg
+          ERROR=""
+          if [ "$PROJECT_FILE" != "setup.cfg" ]; then
+            echo "Unexpected python_project_file: $PROJECT_FILE ❌"
+            ERROR="true"
+          fi
+          if [ "$PROJECT_NAME" != "lfdocs-conf" ]; then
+            echo "Unexpected python_project_name: $PROJECT_NAME ❌"
+            ERROR="true"
+          fi
+          if [ "$PACKAGE_NAME" != "lfdocs_conf" ]; then
+            echo "Unexpected python_package_name: $PACKAGE_NAME ❌"
+            ERROR="true"
+          fi
+          if [ "$SOURCE" != "setup.cfg" ]; then
+            echo "Unexpected source: $SOURCE ❌"
+            ERROR="true"
+          fi
+          if [ "$ERROR" != "true" ]; then
+            echo "All output tests passed for build-system-only fixture ✅"
+          else
+            exit 1
+          fi

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       # Perform setup prior to running test(s)
       - name: "Checkout sample project repository"
@@ -38,6 +40,7 @@ jobs:
         with:
           repository: "lfreleng-actions/test-python-project"
           path: "test-python-project"
+          persist-credentials: false
 
       - name: "Run Action: ${{ github.repository }} [test-python-project]"
         id: test-pyproject-toml
@@ -49,30 +52,35 @@ jobs:
 
       - name: "Validate Action Output: ${{ github.repository }} [test-python-project]"
         shell: bash
+        env:
+          PROJECT_FILE: ${{ steps.test-pyproject-toml.outputs.python_project_file }}
+          PROJECT_NAME: ${{ steps.test-pyproject-toml.outputs.python_project_name }}
+          PACKAGE_NAME: ${{ steps.test-pyproject-toml.outputs.python_package_name }}
+          SOURCE: ${{ steps.test-pyproject-toml.outputs.source }}
         run: |
           # Validate Action Output
-          project_file="${{ steps.test-pyproject-toml.outputs.python_project_file }}"
+          project_file="$PROJECT_FILE"
           if [ "$project_file" != "pyproject.toml" ]; then
             echo "Unexpected return value for: python_project_file ❌"
             echo "Returned: $project_file"
             echo "Expected: pyproject.toml"
             ERROR="true"
           fi
-          project_name="${{ steps.test-pyproject-toml.outputs.python_project_name }}"
+          project_name="$PROJECT_NAME"
           if [ "$project_name" != "lfreleng-test-python-project" ]; then
             echo "Unexpected return value for: python_project_name ❌"
             echo "Returned: $project_name"
             echo "Expected: lfreleng-test-python-project"
             ERROR="true"
           fi
-          package_name="${{ steps.test-pyproject-toml.outputs.python_package_name }}"
+          package_name="$PACKAGE_NAME"
           if [ "$package_name" != "lfreleng_test_python_project" ]; then
             echo "Unexpected return value for: python_package_name ❌"
             echo "Returned: $package_name"
             echo "Expected: lfreleng_test_python_project"
             ERROR="true"
           fi
-          source="${{ steps.test-pyproject-toml.outputs.source }}"
+          source="$SOURCE"
           if [ "$source" != "pyproject.toml" ]; then
             echo "Unexpected return value for: source ❌"
             echo "Returned: $source"
@@ -92,6 +100,7 @@ jobs:
         with:
           repository: "ModeSevenIndustrialSolutions/python-nss-ng"
           path: "python-nss-ng"
+          persist-credentials: false
 
       - name: "Run Action: ${{ github.repository }} [python-nss-ng]"
         id: test-python-nss-ng
@@ -101,30 +110,35 @@ jobs:
 
       - name: "Validate Action Output: ${{ github.repository }} [python-nss-ng]"
         shell: bash
+        env:
+          PROJECT_FILE: ${{ steps.test-python-nss-ng.outputs.python_project_file }}
+          PROJECT_NAME: ${{ steps.test-python-nss-ng.outputs.python_project_name }}
+          PACKAGE_NAME: ${{ steps.test-python-nss-ng.outputs.python_package_name }}
+          SOURCE: ${{ steps.test-python-nss-ng.outputs.source }}
         run: |
           # Validate Action Output
-          project_file="${{ steps.test-python-nss-ng.outputs.python_project_file }}"
+          project_file="$PROJECT_FILE"
           if [ "$project_file" != "pyproject.toml" ]; then
             echo "Unexpected return value for: python_project_file ❌"
             echo "Returned: $project_file"
             echo "Expected: pyproject.toml"
             ERROR="true"
           fi
-          project_name="${{ steps.test-python-nss-ng.outputs.python_project_name }}"
+          project_name="$PROJECT_NAME"
           if [ "$project_name" != "python-nss-ng" ]; then
             echo "Unexpected return value for: python_project_name ❌"
             echo "Returned: $project_name"
             echo "Expected: python-nss-ng"
             ERROR="true"
           fi
-          package_name="${{ steps.test-python-nss-ng.outputs.python_package_name }}"
+          package_name="$PACKAGE_NAME"
           if [ "$package_name" != "python_nss_ng" ]; then
             echo "Unexpected return value for: python_package_name ❌"
             echo "Returned: $package_name"
             echo "Expected: python_nss_ng"
             ERROR="true"
           fi
-          source="${{ steps.test-python-nss-ng.outputs.source }}"
+          source="$SOURCE"
           if [ "$source" != "pyproject.toml" ]; then
             echo "Unexpected return value for: source ❌"
             echo "Returned: $source"

--- a/README.md
+++ b/README.md
@@ -10,16 +10,18 @@ Extracts the Python project name and derives the Python package name.
 ## python-project-name-action
 
 The action probes the project for metadata in the following order,
-selecting the first present file (and, for `setup.cfg`, falling
-through to `setup.py` when the file is present but contains no
-`[metadata] name`):
+selecting the first source that yields a project name. The action
+skips a present source that carries no usable name and continues with
+the next one:
 
 1. `pyproject.toml` — `[project] name` (PEP 621, preferred)
 2. `setup.cfg` — `[metadata] name` (legacy pbr / setuptools projects)
 3. `setup.py` — `name="…"` literal (legacy setuptools)
 
-If the chosen source is present but its name field is missing or
-empty, and no later source remains to try, the action fails rather
+This tolerates a `pyproject.toml` that contains a `[build-system]`
+table (PEP 517) but no `[project] name` — the common pbr / setuptools
+layout — by falling through to `setup.cfg` and then `setup.py` rather
+than aborting. If no source yields a name, the action fails rather
 than emitting an empty value.
 
 The `setup.cfg` and `setup.py` paths exist to support legacy projects

--- a/action.yaml
+++ b/action.yaml
@@ -71,19 +71,27 @@ runs:
         flags: "-oP -m1"
         regex: '(?<=^name = ")([^"]*)'
         filename: "${{ env.path_prefix }}/pyproject.toml"
+        # A pyproject.toml may legitimately carry only a [build-system]
+        # table (PEP 517) with no [project] name, e.g. pbr / setuptools
+        # projects that keep metadata in setup.cfg. Treat "no name" as a
+        # non-fatal empty result so the setup.cfg / setup.py fallbacks can
+        # run, rather than aborting the whole action.
+        no_fail: "true"
 
-    # Fall back to setup.cfg ([metadata] name) for legacy pbr/setuptools
+    # Fall back to setup.cfg ([metadata] name) for legacy pbr/setuptools.
+    # This runs whenever pyproject.toml did not yield a project name,
+    # whether the file is absent or carries only a [build-system] table.
     # yamllint disable-line rule:line-length
     - uses: lfreleng-actions/path-check-action@9606e61c870025bc956e63156d1d55c5df54426c # v0.2.0
       id: setup-cfg
-      if: steps.pyproject-toml.outputs.type != 'file'
+      if: steps.pyproject-name.outputs.extracted_string == ''
       with:
         path: "${{ env.path_prefix }}/setup.cfg"
 
     - name: "Get project name from setup.cfg"
       id: setup-cfg-name
       if: >-
-        steps.pyproject-toml.outputs.type != 'file' &&
+        steps.pyproject-name.outputs.extracted_string == '' &&
         steps.setup-cfg.outputs.type == 'file'
       shell: bash
       run: |
@@ -158,7 +166,7 @@ runs:
     - uses: lfreleng-actions/path-check-action@9606e61c870025bc956e63156d1d55c5df54426c # v0.2.0
       id: setup-py
       if: >-
-        steps.pyproject-toml.outputs.type != 'file' &&
+        steps.pyproject-name.outputs.extracted_string == '' &&
         (steps.setup-cfg.outputs.type != 'file' ||
          steps.setup-cfg-name.outputs.extracted_string == '')
       with:
@@ -167,7 +175,7 @@ runs:
     - name: "Get project name from setup.py"
       id: setup-name
       if: >-
-        steps.pyproject-toml.outputs.type != 'file' &&
+        steps.pyproject-name.outputs.extracted_string == '' &&
         (steps.setup-cfg.outputs.type != 'file' ||
          steps.setup-cfg-name.outputs.extracted_string == '') &&
         steps.setup-py.outputs.type == 'file'
@@ -187,7 +195,6 @@ runs:
         # avoids any chance of repo-controlled values (notably the
         # setup.cfg-derived name) breaking out of shell quoting in
         # this step.
-        PYPROJECT_TOML_TYPE: ${{ steps.pyproject-toml.outputs.type }}
         PYPROJECT_NAME: ${{ steps.pyproject-name.outputs.extracted_string }}
         SETUP_CFG_TYPE: ${{ steps.setup-cfg.outputs.type }}
         SETUP_CFG_NAME: ${{ steps.setup-cfg-name.outputs.extracted_string }}
@@ -197,8 +204,10 @@ runs:
       run: |
         # Capture Python project metadata
 
-        # pyproject.toml is preferred source
-        if [ "$PYPROJECT_TOML_TYPE" = 'file' ]; then
+        # pyproject.toml is the preferred source, but only when it
+        # actually yielded a [project] name. A [build-system]-only file
+        # leaves PYPROJECT_NAME empty and must fall through to setup.cfg.
+        if [ -n "$PYPROJECT_NAME" ]; then
           PYTHON_PROJECT_NAME="$PYPROJECT_NAME"
           PYTHON_PROJECT_FILE="pyproject.toml"
           SOURCE="pyproject.toml"
@@ -219,7 +228,8 @@ runs:
           SOURCE="setup.py"
           echo "Using project name from: setup.py ⚠️"
         else
-          echo "Error: no pyproject.toml, setup.cfg or setup.py found ❌"
+          echo "Error: no project name found in pyproject.toml," \
+            "setup.cfg or setup.py ❌"
           exit 1
         fi
 

--- a/action.yaml
+++ b/action.yaml
@@ -37,11 +37,16 @@ runs:
   steps:
     - name: "Setup action/environment"
       shell: bash
+      env:
+        # Pass the input via the environment rather than interpolating
+        # it directly into the script body, so a hostile value cannot
+        # break out of shell quoting (zizmor: template-injection).
+        INPUT_PATH_PREFIX: ${{ inputs.path_prefix }}
       run: |
         # Setup action/environment
 
         # Handle path_prefix input consistently and when absent
-        path_prefix="${{ inputs.path_prefix }}"
+        path_prefix="$INPUT_PATH_PREFIX"
         if [ -z "$path_prefix" ]; then
           # Set current directory as path prefix
           path_prefix="."
@@ -102,7 +107,10 @@ runs:
         # not picked up. An empty / missing value is not an error
         # here; the caller will fall through to setup.py.
 
-        cfg="${{ env.path_prefix }}/setup.cfg"
+        # path_prefix is exported via GITHUB_ENV by the setup step, so
+        # read it from the environment rather than expanding a template
+        # into this run block (zizmor: template-injection).
+        cfg="$path_prefix/setup.cfg"
         # Match setup.cfg parsing semantics used by configparser
         # (setuptools/pbr): section names and option keys are
         # case-insensitive; either `=` or `:` may delimit the


### PR DESCRIPTION
## Problem

When a repository has a `pyproject.toml` that contains only a `[build-system]`
table (PEP 517) and **no** `[project] name`, the action aborts instead of
resolving the name from `setup.cfg`/`setup.py`.

This is the common **pbr / setuptools-legacy** layout: metadata stays in
`setup.cfg`, while `pyproject.toml` exists purely to declare the build backend.
A real example is `lfdocs-conf`, which recently adopted a PEP 517 build backend
(`pbr.build`) to fix a `pkg_resources`/setuptools build break — and immediately
started failing the `python-audit-action` → `python-project-name-action` step:

```
Run lfreleng-actions/file-grep-regex-action@...
Regular expression to use: (?<=^name = ")([^"]*)
File to search: ./pyproject.toml
String extraction failed; no matching value found ❌
Error: Process completed with exit code 1.
```

## Root cause

The action already has `setup.cfg`/`setup.py` fallbacks, but:

1. The `pyproject.toml` name grep ran **without `no_fail`**, so a nameless file
   exited non-zero and killed the job before any fallback.
2. The fallbacks were gated on `steps.pyproject-toml.outputs.type != 'file'` —
   i.e. they only ran when `pyproject.toml` was **absent**, never when it was
   present-but-nameless.

In short, the action assumed "pyproject.toml present ⇒ name in `[project]`",
which is not true for a `[build-system]`-only file.

## Fix

Minimal, no new dependencies, no behaviour change for PEP 621 projects:

- Add `no_fail: "true"` to the `pyproject.toml` name extraction so "no name"
  is a non-fatal empty result.
- Re-gate the `setup.cfg`/`setup.py` fallback chain on
  `steps.pyproject-name.outputs.extracted_string == ''` (no name resolved)
  rather than on the file being absent. A skipped extraction also yields an
  empty string, so the absent-`pyproject.toml` path is unchanged.
- In the capture step, prefer `pyproject.toml` only when it actually produced a
  name (`[ -n "$PYPROJECT_NAME" ]`); drop the now-unused `PYPROJECT_TOML_TYPE`
  env and tidy the final error message.

## Tests

Adds a fifth fixture to `testing.yaml`: a hybrid project with a
`[build-system]`-only `pyproject.toml` alongside a `setup.cfg [metadata] name`,
asserting the name resolves from `setup.cfg` (`source == setup.cfg`,
`python_package_name == lfdocs_conf`). Existing fixtures (pyproject.toml,
setup.cfg, setup.cfg→setup.py fall-through) are unchanged.

README updated to describe the "first source that yields a name" semantics.

All `pre-commit` hooks pass locally (yamllint, actionlint, markdownlint,
write-good, reuse, codespell, workflow validators).

## Downstream

Once released, `python-audit-action` should bump its pin to pick this up.
